### PR TITLE
Fix message bubble positioning to prevent overlap

### DIFF
--- a/talktalktalk.html
+++ b/talktalktalk.html
@@ -153,8 +153,8 @@ html {
 }
 
 .message-bubble.own {
-    align-self: flex-end;
-    margin-left: auto;
+    align-self: flex-start;
+    margin-right: auto;
 }
 
 .message-bubble.other {
@@ -170,7 +170,7 @@ html {
 }
 
 .message-bubble.own .message-username {
-    text-align: right;
+    text-align: left;
 }
 
 .message-content {


### PR DESCRIPTION
## Problem
Message bubbles were positioned on the right side of the screen, causing overlap issues with the sidebar.

## Solution
This PR fixes the bubble positioning by moving all message bubbles to the left side of the screen.

### Changes Made:
- **CSS Updates**: Modified `.message-bubble.own` alignment from `flex-end` to `flex-start`
- **Consistency**: Updated username text alignment to maintain left-aligned layout
- **Layout**: Changed margin properties to ensure all bubbles align to the left

### Before:
- User's own messages (blue bubbles) appeared on the right side
- Potential overlap with the right sidebar
- Inconsistent positioning

### After:
- All message bubbles now appear on the left side
- No overlap with sidebar
- Clean, consistent left-aligned layout
- Better readability and user experience

## Testing
✅ Tested with multiple messages
✅ Verified consistent left positioning
✅ Confirmed no overlap issues
✅ Username alignment works correctly

This fix resolves the overlap issue while maintaining the modern UI design.

@MYGUYZAHIR can click here to [continue refining the PR](https://app.all-hands.dev/conversations/19c68fdb892549fd97410cfaf379ff37)