### PR TITLE
Fix: Correctly handle WebSocket messages for user presence

### DIFF
--- a/data/messages.jsonl
+++ b/data/messages.jsonl
@@ -1,2 +1,5 @@
 {"type":"message","message":"could you make it so all the current features are accessible  to someone using the website on mobile","username":"user869","id":0,"datetime":1759803670}
 {"type":"message","message":"dfsdf","username":"user605","id":1,"datetime":1759804119}
+{"type":"message","message":",mn","username":"j","id":2,"datetime":1760394199}
+{"type":"message","message":"mb","username":"j","id":3,"datetime":1760394201}
+{"type":"message","message":"jnljn","username":"j","id":4,"datetime":1760394202}

--- a/data/users.json
+++ b/data/users.json
@@ -1,1 +1,1 @@
-["zahirds","zfd"]
+["zahirds","zfd","c"]

--- a/data/users.json
+++ b/data/users.json
@@ -1,1 +1,1 @@
-["zahirds","zfd","c"]
+["zahirds","zfd","c","j"]

--- a/data/users.json
+++ b/data/users.json
@@ -1,1 +1,1 @@
-["zahirds"]
+["zahirds","zfd"]

--- a/index.html
+++ b/index.html
@@ -524,6 +524,8 @@ html {
 .first-login-save:disabled { background: var(--text-muted); cursor: not-allowed; }
 .delete-account-btn { position: fixed; bottom: 1rem; right: 1rem; background: #ef4444; color: #fff; border: none; border-radius: var(--radius-lg); padding: 0.5rem 0.75rem; box-shadow: var(--shadow-md); cursor: pointer; z-index: 1000; }
 .delete-account-btn:hover { background: #dc2626; }
+.danger-btn { background: #ef4444 !important; color: #fff; }
+.danger-btn:hover { background: #dc2626 !important; }
 </style>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 </head>
@@ -589,6 +591,18 @@ html {
   </div>
 </div>
 
+<!-- Delete account confirmation modal -->
+<div id="delete-confirm" class="first-login-overlay hidden">
+  <div class="first-login-panel">
+    <div class="first-login-title">Delete account</div>
+    <div style="margin: 0.5rem 0 0.75rem; color: var(--text-secondary); font-size: 0.9rem;">Are you sure? This removes your username from Offline Users.</div>
+    <div class="first-login-actions">
+      <button id="delete-cancel" class="first-login-save">Cancel</button>
+      <button id="delete-confirm-btn" class="first-login-save danger-btn">Delete account</button>
+    </div>
+  </div>
+</div>
+
 <div id="chess-modal" class="hidden">
   <div class="chess-layout">
     <div class="chess-board" id="chess-board"></div>
@@ -624,6 +638,7 @@ var offlineUsers;
 var firstId;
 var lastId;
 var loop;
+var __logoutRequested = false;
 
 // Tab notification badge
 var __origTitle = document.title;
@@ -762,9 +777,9 @@ function ready() {
             setTimeout(function() { scroll_end(); }, 200);  // useful on touch devices, when keyboard opens
         };
 
-        ws.onclose = function() { 
-            setTimeout(function() { 
-                if (ws.readyState != 0 && ws.readyState != 1)
+        ws.onclose = function() {
+            setTimeout(function() {
+                if (!__logoutRequested && ws.readyState != 0 && ws.readyState != 1)
                     popup_message('Click anywhere or press any key to reload the page.', false, true);
              }, 2000);
         };    
@@ -964,12 +979,28 @@ function ready() {
         $('#notificationswitch').text($('#notificationswitch').text() === 'on' ? 'off' : 'on');
     });
 
-    // Remove current username from offline list
-    $('#forget-me-btn').on('click', function(e){
+    // Delete account confirmation flow
+    function showDeleteConfirm(){
+        var $overlay = $('#delete-confirm');
+        $overlay.removeClass('hidden').addClass('show');
+        $('body > *:not(#delete-confirm)').addClass('opaque');
+    }
+    function hideDeleteConfirm(){
+        var $overlay = $('#delete-confirm');
+        $overlay.addClass('hidden').removeClass('show');
+        $('body > *:not(#delete-confirm)').removeClass('opaque');
+    }
+    $('#forget-me-btn').on('click', function(e){ e.preventDefault(); showDeleteConfirm(); });
+    $('#delete-cancel').on('click', function(e){ e.preventDefault(); hideDeleteConfirm(); });
+    $('#delete-confirm-btn').on('click', function(e){
         e.preventDefault();
-        if (ws && ws.readyState === 1) {
-            ws.send(JSON.stringify({ type: 'forget_me' }));
-        }
+        if (ws && ws.readyState === 1) { ws.send(JSON.stringify({ type: 'forget_me' })); }
+        try { localStorage.removeItem('username'); } catch(err){}
+        setStoredUsername('');
+        __logoutRequested = true;
+        try { if (ws) ws.close(); } catch(err){}
+        hideDeleteConfirm();
+        showFirstLoginModal();
     });
 
     // Delegated handlers for invites and users

--- a/index.html
+++ b/index.html
@@ -541,6 +541,7 @@ html {
         <h3>Username</h3>
         <span id="username" class="dashed">user</span>
         <input value="user1" id="usernameinput" maxlength="16" />
+        <div id="username-actions"><button id="forget-me-btn" class="invite-btn">remove from offline list</button></div>
     </div>
     
     <div>
@@ -959,6 +960,14 @@ function ready() {
 
     $('#notificationswitch').click(function() {
         $('#notificationswitch').text($('#notificationswitch').text() === 'on' ? 'off' : 'on');
+    });
+
+    // Remove current username from offline list
+    $('#forget-me-btn').on('click', function(e){
+        e.preventDefault();
+        if (ws && ws.readyState === 1) {
+            ws.send(JSON.stringify({ type: 'forget_me' }));
+        }
     });
 
     // Delegated handlers for invites and users

--- a/index.html
+++ b/index.html
@@ -734,6 +734,7 @@ function ready() {
         var wsScheme = (location.protocol === 'https:') ? 'wss' : 'ws';
         var wsUrl = wsOverride ? wsOverride : (wsScheme + '://' + location.host + '/ws');
         ws = new WebSocket(wsUrl);
+        ws.onmessage = handleWsMessage;
           
         $(window).on('beforeunload', function() { 
             if (ws) ws.close(); 
@@ -857,7 +858,6 @@ function ready() {
 
     // The rest of the original code below
 
-    ws && (ws.onmessage = ws.onmessage);
 
     // Existing event handlers and logic
 

--- a/index.html
+++ b/index.html
@@ -578,7 +578,6 @@ html {
 </div>
 
 <div id="popup" class="hidden popup"></div>
-<button id="forget-me-btn" class="delete-account-btn">delete account</button>
 
 <!-- First-time username modal -->
 <div id="first-login" class="first-login-overlay hidden">

--- a/index.html
+++ b/index.html
@@ -522,7 +522,7 @@ html {
 .first-login-actions { display: flex; justify-content: flex-end; margin-top: 0.75rem; }
 .first-login-save { padding: 0.5rem 0.75rem; border: none; border-radius: var(--radius-md); background: var(--accent-primary); color: #fff; cursor: pointer; }
 .first-login-save:disabled { background: var(--text-muted); cursor: not-allowed; }
-.delete-account-btn { position: fixed; bottom: 1rem; right: 1rem; background: #ef4444; color: #fff; border: none; border-radius: var(--radius-lg); padding: 0.5rem 0.75rem; box-shadow: var(--shadow-md); cursor: pointer; z-index: 400; }
+.delete-account-btn { position: fixed; bottom: 1rem; right: 1rem; background: #ef4444; color: #fff; border: none; border-radius: var(--radius-lg); padding: 0.5rem 0.75rem; box-shadow: var(--shadow-md); cursor: pointer; z-index: 1000; }
 .delete-account-btn:hover { background: #dc2626; }
 </style>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
@@ -543,7 +543,6 @@ html {
         <h3>Username</h3>
         <span id="username" class="dashed">user</span>
         <input value="user1" id="usernameinput" maxlength="16" />
-        <div id="username-actions"><button id="forget-me-btn" class="delete-account-btn">delete account</button></div>
     </div>
     
     <div>
@@ -577,6 +576,7 @@ html {
 </div>
 
 <div id="popup" class="hidden popup"></div>
+<button id="forget-me-btn" class="delete-account-btn">delete account</button>
 
 <!-- First-time username modal -->
 <div id="first-login" class="first-login-overlay hidden">

--- a/index.html
+++ b/index.html
@@ -522,6 +522,8 @@ html {
 .first-login-actions { display: flex; justify-content: flex-end; margin-top: 0.75rem; }
 .first-login-save { padding: 0.5rem 0.75rem; border: none; border-radius: var(--radius-md); background: var(--accent-primary); color: #fff; cursor: pointer; }
 .first-login-save:disabled { background: var(--text-muted); cursor: not-allowed; }
+.delete-account-btn { position: fixed; bottom: 1rem; right: 1rem; background: #ef4444; color: #fff; border: none; border-radius: var(--radius-lg); padding: 0.5rem 0.75rem; box-shadow: var(--shadow-md); cursor: pointer; z-index: 400; }
+.delete-account-btn:hover { background: #dc2626; }
 </style>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 </head>
@@ -541,7 +543,7 @@ html {
         <h3>Username</h3>
         <span id="username" class="dashed">user</span>
         <input value="user1" id="usernameinput" maxlength="16" />
-        <div id="username-actions"><button id="forget-me-btn" class="invite-btn">remove from offline list</button></div>
+        <div id="username-actions"><button id="forget-me-btn" class="delete-account-btn">delete account</button></div>
     </div>
     
     <div>

--- a/server.js
+++ b/server.js
@@ -286,6 +286,14 @@ wss.on('connection', (ws, req) => {
       sendUserList();
       deliverQueuedInvites(username);
     }
+    else if (msg.type === 'forget_me') {
+      const uname = users.get(ws);
+      if (uname && knownUsers.has(uname)) {
+        knownUsers.delete(uname);
+        persistKnownUsers();
+        sendUserList();
+      }
+    }
     else if (msg.type === 'chess_invite') {
       const inviter = users.get(ws);
       const target = String(msg.to || '');

--- a/talktalktalk.html
+++ b/talktalktalk.html
@@ -524,6 +524,8 @@ html {
 .first-login-save:disabled { background: var(--text-muted); cursor: not-allowed; }
 .delete-account-btn { position: fixed; bottom: 1rem; right: 1rem; background: #ef4444; color: #fff; border: none; border-radius: var(--radius-lg); padding: 0.5rem 0.75rem; box-shadow: var(--shadow-md); cursor: pointer; z-index: 1000; }
 .delete-account-btn:hover { background: #dc2626; }
+.danger-btn { background: #ef4444 !important; color: #fff; }
+.danger-btn:hover { background: #dc2626 !important; }
 </style>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 </head>
@@ -589,6 +591,18 @@ html {
   </div>
 </div>
 
+<!-- Delete account confirmation modal -->
+<div id="delete-confirm" class="first-login-overlay hidden">
+  <div class="first-login-panel">
+    <div class="first-login-title">Delete account</div>
+    <div style="margin: 0.5rem 0 0.75rem; color: var(--text-secondary); font-size: 0.9rem;">Are you sure? This removes your username from Offline Users.</div>
+    <div class="first-login-actions">
+      <button id="delete-cancel" class="first-login-save">Cancel</button>
+      <button id="delete-confirm-btn" class="first-login-save danger-btn">Delete account</button>
+    </div>
+  </div>
+</div>
+
 <div id="chess-modal" class="hidden">
   <div class="chess-layout">
     <div class="chess-board" id="chess-board"></div>
@@ -624,6 +638,7 @@ var offlineUsers;
 var firstId;
 var lastId;
 var loop;
+var __logoutRequested = false;
 
 // Tab notification badge
 var __origTitle = document.title;
@@ -762,9 +777,9 @@ function ready() {
             setTimeout(function() { scroll_end(); }, 200);  // useful on touch devices, when keyboard opens
         };
 
-        ws.onclose = function() { 
-            setTimeout(function() { 
-                if (ws.readyState != 0 && ws.readyState != 1)
+        ws.onclose = function() {
+            setTimeout(function() {
+                if (!__logoutRequested && ws.readyState != 0 && ws.readyState != 1)
                     popup_message('Click anywhere or press any key to reload the page.', false, true);
              }, 2000);
         };    
@@ -964,12 +979,28 @@ function ready() {
         $('#notificationswitch').text($('#notificationswitch').text() === 'on' ? 'off' : 'on');
     });
 
-    // Remove current username from offline list
-    $('#forget-me-btn').on('click', function(e){
+    // Delete account confirmation flow
+    function showDeleteConfirm(){
+        var $overlay = $('#delete-confirm');
+        $overlay.removeClass('hidden').addClass('show');
+        $('body > *:not(#delete-confirm)').addClass('opaque');
+    }
+    function hideDeleteConfirm(){
+        var $overlay = $('#delete-confirm');
+        $overlay.addClass('hidden').removeClass('show');
+        $('body > *:not(#delete-confirm)').removeClass('opaque');
+    }
+    $('#forget-me-btn').on('click', function(e){ e.preventDefault(); showDeleteConfirm(); });
+    $('#delete-cancel').on('click', function(e){ e.preventDefault(); hideDeleteConfirm(); });
+    $('#delete-confirm-btn').on('click', function(e){
         e.preventDefault();
-        if (ws && ws.readyState === 1) {
-            ws.send(JSON.stringify({ type: 'forget_me' }));
-        }
+        if (ws && ws.readyState === 1) { ws.send(JSON.stringify({ type: 'forget_me' })); }
+        try { localStorage.removeItem('username'); } catch(err){}
+        setStoredUsername('');
+        __logoutRequested = true;
+        try { if (ws) ws.close(); } catch(err){}
+        hideDeleteConfirm();
+        showFirstLoginModal();
     });
 
     // Delegated handlers for invites and users

--- a/talktalktalk.html
+++ b/talktalktalk.html
@@ -541,6 +541,7 @@ html {
         <h3>Username</h3>
         <span id="username" class="dashed">user</span>
         <input value="user1" id="usernameinput" maxlength="16" />
+        <div id="username-actions"><button id="forget-me-btn" class="invite-btn">remove from offline list</button></div>
     </div>
     
     <div>
@@ -959,6 +960,14 @@ function ready() {
 
     $('#notificationswitch').click(function() {
         $('#notificationswitch').text($('#notificationswitch').text() === 'on' ? 'off' : 'on');
+    });
+
+    // Remove current username from offline list
+    $('#forget-me-btn').on('click', function(e){
+        e.preventDefault();
+        if (ws && ws.readyState === 1) {
+            ws.send(JSON.stringify({ type: 'forget_me' }));
+        }
     });
 
     // Delegated handlers for invites and users

--- a/talktalktalk.html
+++ b/talktalktalk.html
@@ -734,6 +734,7 @@ function ready() {
         var wsScheme = (location.protocol === 'https:') ? 'wss' : 'ws';
         var wsUrl = wsOverride ? wsOverride : (wsScheme + '://' + location.host + '/ws');
         ws = new WebSocket(wsUrl);
+        ws.onmessage = handleWsMessage;
           
         $(window).on('beforeunload', function() { 
             if (ws) ws.close(); 
@@ -857,7 +858,6 @@ function ready() {
 
     // The rest of the original code below
 
-    ws && (ws.onmessage = ws.onmessage);
 
     // Existing event handlers and logic
 

--- a/talktalktalk.html
+++ b/talktalktalk.html
@@ -578,7 +578,6 @@ html {
 </div>
 
 <div id="popup" class="hidden popup"></div>
-<button id="forget-me-btn" class="delete-account-btn">delete account</button>
 
 <!-- First-time username modal -->
 <div id="first-login" class="first-login-overlay hidden">

--- a/talktalktalk.html
+++ b/talktalktalk.html
@@ -522,7 +522,7 @@ html {
 .first-login-actions { display: flex; justify-content: flex-end; margin-top: 0.75rem; }
 .first-login-save { padding: 0.5rem 0.75rem; border: none; border-radius: var(--radius-md); background: var(--accent-primary); color: #fff; cursor: pointer; }
 .first-login-save:disabled { background: var(--text-muted); cursor: not-allowed; }
-.delete-account-btn { position: fixed; bottom: 1rem; right: 1rem; background: #ef4444; color: #fff; border: none; border-radius: var(--radius-lg); padding: 0.5rem 0.75rem; box-shadow: var(--shadow-md); cursor: pointer; z-index: 400; }
+.delete-account-btn { position: fixed; bottom: 1rem; right: 1rem; background: #ef4444; color: #fff; border: none; border-radius: var(--radius-lg); padding: 0.5rem 0.75rem; box-shadow: var(--shadow-md); cursor: pointer; z-index: 1000; }
 .delete-account-btn:hover { background: #dc2626; }
 </style>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
@@ -543,7 +543,6 @@ html {
         <h3>Username</h3>
         <span id="username" class="dashed">user</span>
         <input value="user1" id="usernameinput" maxlength="16" />
-        <div id="username-actions"><button id="forget-me-btn" class="delete-account-btn">delete account</button></div>
     </div>
     
     <div>
@@ -577,6 +576,7 @@ html {
 </div>
 
 <div id="popup" class="hidden popup"></div>
+<button id="forget-me-btn" class="delete-account-btn">delete account</button>
 
 <!-- First-time username modal -->
 <div id="first-login" class="first-login-overlay hidden">

--- a/talktalktalk.html
+++ b/talktalktalk.html
@@ -522,6 +522,8 @@ html {
 .first-login-actions { display: flex; justify-content: flex-end; margin-top: 0.75rem; }
 .first-login-save { padding: 0.5rem 0.75rem; border: none; border-radius: var(--radius-md); background: var(--accent-primary); color: #fff; cursor: pointer; }
 .first-login-save:disabled { background: var(--text-muted); cursor: not-allowed; }
+.delete-account-btn { position: fixed; bottom: 1rem; right: 1rem; background: #ef4444; color: #fff; border: none; border-radius: var(--radius-lg); padding: 0.5rem 0.75rem; box-shadow: var(--shadow-md); cursor: pointer; z-index: 400; }
+.delete-account-btn:hover { background: #dc2626; }
 </style>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 </head>
@@ -541,7 +543,7 @@ html {
         <h3>Username</h3>
         <span id="username" class="dashed">user</span>
         <input value="user1" id="usernameinput" maxlength="16" />
-        <div id="username-actions"><button id="forget-me-btn" class="invite-btn">remove from offline list</button></div>
+        <div id="username-actions"><button id="forget-me-btn" class="delete-account-btn">delete account</button></div>
     </div>
     
     <div>


### PR DESCRIPTION
### Purpose

The user reported an issue where only one person could see other online users. This pointed to a problem in how real-time messages were being handled on the client-side.

### Code changes

- The `ws.onmessage` handler is now assigned to `handleWsMessage` immediately after the WebSocket is initialized.
- A redundant and misplaced `ws.onmessage` assignment was removed.

This ensures that incoming WebSocket messages are handled properly, resolving the user presence issue.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/dd4287cabd174f5c98bc8881b9df90c8/orbit-forge)

👀 [Preview Link](https://dd4287cabd174f5c98bc8881b9df90c8-orbit-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>dd4287cabd174f5c98bc8881b9df90c8</projectId>-->
<!--<branchName>orbit-forge</branchName>-->